### PR TITLE
Update Favorites in kickoffrc (boo#1099859)

### DIFF
--- a/config-files/etc/xdg/kickoffrc
+++ b/config-files/etc/xdg/kickoffrc
@@ -1,5 +1,2 @@
-[Branding]
-Homepage=http://www.opensuse.org/
-
 [Favorites]
-FavoriteURLs=/usr/share/applications/firefox.desktop,/usr/share/applications/kde4/Kontact.desktop,/usr/share/applications/writer.desktop,/usr/share/applications/kde4/amarok.desktop,/usr/share/applications/kde4/digikam.desktop,/usr/share/applications/org.kde.dolphin.desktop,/usr/share/applications/systemsettings.desktop,/usr/share/applications/kde4/Help.desktop,/usr/share/applications/org.kde.konsole.desktop
+FavoriteURLs=/usr/share/applications/firefox.desktop,/usr/share/applications/org.kde.kontact.desktop,/usr/share/applications/writer.desktop,/usr/share/applications/kde4/amarok.desktop,/usr/share/applications/org.kde.digikam.desktop,/usr/share/applications/org.kde.dolphin.desktop,/usr/share/applications/systemsettings.desktop,/usr/share/applications/org.kde.Help.desktop,/usr/share/applications/org.kde.konsole.desktop


### PR DESCRIPTION
As we use kickoff by default now, this file again sets the default Favorites (it is respected by the obsolete_kickoffrc.js Plasma update
script run on first login), so adjust them to the current paths/names for those applications that have been ported to KF5.

Also remove the [Branding] section, it is not used anymore.