### PR TITLE
Revert "Add systemsettingsrc to use the old icon view by default again"

### DIFF
--- a/config-files/etc/xdg/systemsettingsrc
+++ b/config-files/etc/xdg/systemsettingsrc
@@ -1,3 +1,0 @@
-[Main]
-ActiveView=icon_mode
-


### PR DESCRIPTION
This reverts commit 3f11a0c46983246e1fed3a65f62292f9c9f13865.

In Plasma 5.15 the new view is usable now with proper default window sizes,
improved text rendering and working keyboard navigation.

It needs to be tested whether the fixes in Frameworks and the Plasma/5.12 branch
are enough and if so, this can go to 15.1 as well.