### PR TITLE
konversationrc: change #opensuse to #suse

### DIFF
--- a/config-files/etc/xdg/konversationrc
+++ b/config-files/etc/xdg/konversationrc
@@ -1,5 +1,5 @@
 [Channel 0]
-Name=#opensuse
+Name=#suse
 
 [Server 0]
 Server=irc.opensuse.org


### PR DESCRIPTION
#opensuse channel has been redirected to #suse so it is better to set #suse as default channel.