### PR TITLE
Improve blur effect of panels, widgets and popups

### DIFF
--- a/config-files/usr/share/plasma/desktoptheme/openSUSE/metadata.desktop
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSE/metadata.desktop
@@ -21,7 +21,7 @@ defaultWidth=1920
 defaultHeight=1080
 
 [ContrastEffect]
+enabled=false
+
+[BlurBehindEffect]
 enabled=true
-contrast=0.2
-intensity=2.0
-saturation=1.7


### PR DESCRIPTION
Current theme settings used ContrastEffect, which decreased the blur semi-transparent effect. Disabling it seems better for those who like to use photos as wallpaper.

Before:

![Screenshot_20190609_184127](https://user-images.githubusercontent.com/5836790/59161092-bb3da000-8ae6-11e9-95df-32d04aab527b.png)

After:

![Screenshot_20190609_183827](https://user-images.githubusercontent.com/5836790/59161094-c264ae00-8ae6-11e9-88d6-1663059c9384.png)
