### PR TITLE
Link start-here-branding into breeze-dark as well

### DIFF
--- a/config-files/usr/share/icons/breeze-dark/places/16/start-here-branding.svg
+++ b/config-files/usr/share/icons/breeze-dark/places/16/start-here-branding.svg
@@ -1,0 +1,1 @@
+../../../breeze/places/16/start-here-branding.svg

--- a/config-files/usr/share/icons/breeze-dark/places/16/start-here-branding.svgz
+++ b/config-files/usr/share/icons/breeze-dark/places/16/start-here-branding.svgz
@@ -1,0 +1,1 @@
+../../../breeze/places/16/start-here-branding.svgz


### PR DESCRIPTION
That way it can be selected when using breeze-dark icons with a lnf other than
openSUSE.

Fixes boo#1173437.