### PR TITLE
desktoptheme: Enable `AdaptiveTransparency`

### DIFF
--- a/config-files/usr/share/plasma/desktoptheme/openSUSE/metadata.desktop
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSE/metadata.desktop
@@ -24,3 +24,6 @@ enabled=true
 contrast=0.2
 intensity=2.0
 saturation=1.7
+
+[AdaptiveTransparency]
+enabled=true

--- a/config-files/usr/share/plasma/desktoptheme/openSUSEdark/metadata.desktop
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSEdark/metadata.desktop
@@ -21,3 +21,6 @@ defaultWallpaperTheme=openSUSEdefault
 defaultFileSuffix=.jpg
 defaultWidth=1920
 defaultHeight=1080
+
+[AdaptiveTransparency]
+enabled=true

--- a/config-files/usr/share/plasma/desktoptheme/openSUSEdefault/metadata.desktop
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSEdefault/metadata.desktop
@@ -18,4 +18,5 @@ X-KDE-PluginInfo-EnabledByDefault=true
 [Settings]
 FallbackTheme=air
 
-
+[AdaptiveTransparency]
+enabled=true

--- a/config-files/usr/share/plasma/desktoptheme/openSUSElight/metadata.desktop
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSElight/metadata.desktop
@@ -27,3 +27,6 @@ enabled=true
 contrast=0.2
 intensity=2.0
 saturation=1.7
+
+[AdaptiveTransparency]
+enabled=true


### PR DESCRIPTION
The property is required to enable the panel opacity settings in Plasma.

![Opacity](https://user-images.githubusercontent.com/23738961/167114396-5b69b7c2-053a-4fcd-b56a-86c8de7b61bf.png)
