### PR TITLE
Use logo provided by distribution-logos-openSUSE-icons

### DIFF
--- a/config-files/etc/xdg/kcm-about-distrorc
+++ b/config-files/etc/xdg/kcm-about-distrorc
@@ -1,4 +1,3 @@
 [General]
-LogoPath=/usr/share/icons/hicolor/scalable/apps/openSUSE-distributor-logo.svg
+LogoPath=/usr/share/icons/hicolor/scalable/apps/distributor-logo.svg
 Website=https://www.opensuse.org
-


### PR DESCRIPTION
On MicroOS the current configuration leads to mistakenly use the Leap icon in i.e. KInfoCenter5 (the icon provided by `plasma5-theme-openSUSE`). Let's make it use the icon provided by `distribution-logos-openSUSE-icons` instead. This is a link set by the aforementioned package to the appropriate icon for the distribution.