### PR TITLE
Remove font settings (except for fixed) from kdeglobals 

### DIFF
--- a/config-files/etc/xdg/kdeglobals
+++ b/config-files/etc/xdg/kdeglobals
@@ -1,13 +1,7 @@
 [General]
 shadeSortColumn=true
 BrowserApplication=firefox
-desktopFont=Noto Sans,10,-1,5,50,0,0,0,0,0,Regular
-fixed=Hack,9,-1,5,50,0,0,0,0,0,Regular
-font=Noto Sans,10,-1,5,50,0,0,0,0,0,Regular
-menuFont=Noto Sans,10,-1,5,50,0,0,0,0,0,Regular
-smallestReadableFont=Noto Sans,8,-1,5,50,0,0,0,0,0,Regular
-taskbarFont=Noto Sans,10,-1,5,50,0,0,0,0,0,Regular
-toolBarFont=Noto Sans,9,-1,5,50,0,0,0,0,0,Regular
+fixed=Hack,9,-1,5,50,0,0,0,0,0
 # For some reason the LNF's defaults file is not always read,
 # so set the color scheme here as well.
 ColorScheme=BreezeClassic


### PR DESCRIPTION
It's the upstream default anyway, except for the toolbar and fixed font size.
The toolbar font was overridden by fonts_global_toolbar.upd, so just keep the fixed
one.