### PR TITLE
Add opensuse_launcher_icon.js shell update script

### DIFF
--- a/config-files/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/opensuse_launcher_icon.js
+++ b/config-files/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/opensuse_launcher_icon.js
@@ -1,0 +1,36 @@
+/* Plasma 6 no longer uses start-here-branding by default, it needs to be set explicitly.
+ * Utility functions from https://develop.kde.org/docs/plasma/scripting/examples/. */
+
+function forEachWidgetInContainmentList(containmentList, callback) {
+    for (var containmentIndex = 0; containmentIndex < containmentList.length; containmentIndex++) {
+        var containment = containmentList[containmentIndex];
+
+        var widgets = containment.widgets();
+        for (var widgetIndex = 0; widgetIndex < widgets.length; widgetIndex++) {
+            var widget = widgets[widgetIndex];
+            callback(widget, containment);
+            if (widget.type === "org.kde.plasma.systemtray") {
+                systemtrayId = widget.readConfig("SystrayContainmentId");
+                if (systemtrayId) {
+                    forEachWidgetInContainmentList([desktopById(systemtrayId)], callback)
+                }
+            }
+        }
+    }
+}
+
+function forEachWidget(callback) {
+    forEachWidgetInContainmentList(desktops(), callback);
+    forEachWidgetInContainmentList(panels(), callback);
+}
+
+forEachWidget(function(widget, containment) {
+    if (widget.type != "org.kde.plasma.kicker" && widget.type != "org.kde.plasma.kickoff")
+         return;
+
+    widget.currentConfigGroup = ["General"];
+    print("Icon for " + widget.type + ": " + widget.readConfig("icon"));
+    // If using the builtin hardcoded default, switch to the branding icon
+    if (widget.readConfig("icon") == "")
+        widget.writeConfig("icon", "start-here-branding")
+});


### PR DESCRIPTION
Plasma 6 no longer uses desktop theme supplied icons for kick{er,off}, so it has to be set manually on panel creation (done by the layout template) and upgrades (this commit).