### PR TITLE
Look up for .png background by default boo#1222546

### DIFF
--- a/config-files/usr/share/plasma/desktoptheme/openSUSE/plasmarc
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSE/plasmarc
@@ -1,6 +1,6 @@
 [Wallpaper]
 defaultWallpaperTheme=openSUSEdefault
-defaultFileSuffix=.jpg
+defaultFileSuffix=.png
 defaultWidth=1920
 defaultHeight=1080
 

--- a/config-files/usr/share/plasma/desktoptheme/openSUSEdark/plasmarc
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSEdark/plasmarc
@@ -3,7 +3,7 @@ FallbackTheme=breeze-dark
 
 [Wallpaper]
 defaultWallpaperTheme=openSUSEdefault
-defaultFileSuffix=.jpg
+defaultFileSuffix=.png
 defaultWidth=1920
 defaultHeight=1080
 

--- a/config-files/usr/share/plasma/desktoptheme/openSUSElight/plasmarc
+++ b/config-files/usr/share/plasma/desktoptheme/openSUSElight/plasmarc
@@ -3,7 +3,7 @@ FallbackTheme=breeze-light
 
 [Wallpaper]
 defaultWallpaperTheme=openSUSEdefault
-defaultFileSuffix=.jpg
+defaultFileSuffix=.png
 defaultWidth=1920
 defaultHeight=1080
 


### PR DESCRIPTION
Default suffix for openSUSE (as well as SLE) wallpapers should be now .png. Starting by Leap 16 and Tumbleweed.
Related to https://github.com/openSUSE/branding/pull/149

Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1222540